### PR TITLE
Simplify browbeat execution and facilitate running in CI environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ infrared browbeat -h
 ## Usage
 
 To install and run browbeat on your TripleO cloud
- 
+
 ```
-infrared browbeat --install yes --config-file <filename> --workloads <rally,shaker,perfkit> -e @<ansible_vars_file>
+infrared browbeat --install yes --config-file <filename> -e @<ansible_vars_file>
 ```
 
 If you want to install and run workloads along with monitoring and visuzalization
 
 ```
-infrared browbeat --install yes --config-file <filename> --workloads <rally/shaker/perfkit> --monitor yes --visualize yes -e @<ansible_vars_file>
+infrared browbeat --install yes --config-file <filename> --monitor yes --visualize yes -e @<ansible_vars_file>
 ```
 If browbeat is already installed, you can skip the --install flag or set it to no to skip the installation.
 
 Passing the extra argument -e @<ansible_vars_file> is mandatory or the plugin will fail. A sample file is provided [here](vars/all.yml)
-    
+
 ## Tests
 
 To run Ansible linting tests, run the following command

--- a/install.yml
+++ b/install.yml
@@ -19,6 +19,6 @@
     - { role: images, when: browbeat_upload_guest_images}
     - { role: workloads, when: install_browbeat_workloads}
     - shaker-image
+    - stockpile
+    - template-configs
   environment: "{{proxy_env}}"
-
-

--- a/plugin.spec
+++ b/plugin.spec
@@ -16,10 +16,6 @@ subparsers:
                       type: FileValue
                       help: |
                         The browbeat configuration to execute
-                  workloads:
-                      type: Value
-                      help: |
-                        The workloads to run, comma separated (rally,shaker.perfkit)
                   monitor:
                       type: Bool
                       help: |
@@ -29,4 +25,4 @@ subparsers:
                       type: Bool
                       help:
                         Visualize system metrics through grafana dashboards
-                      default: False      
+                      default: False

--- a/roles/stockpile/tasks/main.yml
+++ b/roles/stockpile/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Clone stockpile
+  git:
+    repo: 'http://github.com/redhat-performance/stockpile.git'
+    dest: "{{ browbeat_path }}/ansible/gather/stockpile"
+    version: master
+    force: yes

--- a/roles/template-configs/tasks/main.yml
+++ b/roles/template-configs/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Template Browbeat configuration
+  template:
+    src: "{{ browbeat_config_file }}"
+    dest: "{{ ansible_env.HOME }}/browbeat/browbeat-config.yaml"

--- a/roles/template-configs/templates/browbeat-minimal-ci.yaml.j2
+++ b/roles/template-configs/templates/browbeat-minimal-ci.yaml.j2
@@ -1,0 +1,121 @@
+# Tests to be completed for the install-and-check.sh script minimal and short workloads are performed
+#  to confirm functionality.
+browbeat:
+  cloud_name: {{ browbeat_cloud_name }}
+  rerun: 1
+  rerun_type: iteration
+ansible:
+  hosts: ansible/hosts
+  metadata_playbook: ansible/gather/stockpile.yml
+  ssh_config: ansible/ssh-config
+elasticsearch:
+  enabled: {{ browbeat_elastic_enabled }}
+  host: {{ browbeat_elastic_host }}
+  port: 9200
+  regather: false
+  metadata_files:
+    - name: hardware-metadata
+      file: metadata/hardware-metadata.json
+    - name: environment-metadata
+      file: metadata/environment-metadata.json
+    - name: software-metadata
+      file: metadata/software-metadata.json
+    - name: version
+      file: metadata/version.json
+grafana:
+  enabled: {{ browbeat_grafana_enabled }}
+  host: {{ browbeat_grafana_host }}
+  port: 3000
+  dashboards:
+    - openstack-general-system-performance
+perfkit:
+  sleep_before: 0
+  sleep_after: 0
+  default:
+    image: centos7
+    machine_type: m1.small
+    os_type: rhel
+    openstack_image_username: centos
+    openstack_floating_ip_pool: browbeat_public
+    openstack_network: browbeat_private
+    timing_measurements: runtimes
+    ignore_package_requirements: true
+rally:
+  sleep_before: 5
+  sleep_after: 5
+  plugins:
+    - netcreate-boot: rally/rally-plugins/netcreate-boot
+shaker:
+  server: 1.1.1.1
+  port: 5555
+  flavor: m1.small
+  join_timeout: 600
+  sleep_before: 0
+  sleep_after: 0
+  shaker_region: regionOne
+  external_host: 2.2.2.2
+yoda:
+  instackenv: "/home/stack/instackenv.json"
+  stackrc: "/home/stack/stackrc"
+
+workloads:
+  - name: authenticate
+    enabled: true
+    type: rally
+    concurrency:
+      - 1
+    times: 1
+    scenarios:
+      - name: authentic-keystone
+        enabled: true
+        file: rally/authenticate/keystone-cc.yml
+
+  - name: keystonebasic
+    enabled: true
+    type: rally
+    concurrency:
+      - 1
+    times: 1
+    scenarios:
+      - name: create-and-list-tenants
+        enabled: true
+        file: rally/keystonebasic/create_and_list_tenants-cc.yml
+
+  - name: neutron
+    enabled: true
+    type: rally
+    concurrency:
+      - 1
+    times: 1
+    scenarios:
+      - name: create-list-network
+        enabled: true
+        file: rally/neutron/neutron-create-list-network-cc.yml
+
+  - name: nova
+    enabled: true
+    type: rally
+    concurrency:
+      - 1
+    times: 1
+    scenarios:
+      - name: boot-snapshot-delete
+        enabled: true
+        file: rally/nova/nova-boot-snapshot-cc.yml
+        image_name: cirros
+        flavor_name: m1.xtiny
+
+  - name: plugins
+    enabled: true
+    type: rally
+    concurrency:
+      - 1
+    times: 1
+    scenarios:
+      - name: netcreate-1-boot
+        enabled: true
+        enable_dhcp: true
+        image_name: cirros
+        flavor_name: m1.tiny
+        num_networks: 1
+        file: rally/rally-plugins/netcreate-boot/netcreate_nova_boot.yml

--- a/roles/template-configs/vars/main.yml
+++ b/roles/template-configs/vars/main.yml
@@ -1,0 +1,6 @@
+browbeat_elastic_enabled: false
+browbeat_elastic_host: "1.2.3.4.5"
+browbeat_grafana_enabled: false
+browbeat_grafana_host: "1.2.3.4.5"
+browbeat_config_file: "browbeat-minimal.yaml.j2"
+browbeat_cloud_name: "browbeat_qe_ci"

--- a/run.yml
+++ b/run.yml
@@ -1,20 +1,10 @@
 ---
 - hosts: tester
   tasks:
-    - name: Set browbeat config 
-      set_fact:
-         browbeat_config_file: "{{ ((test|default('')).config|default('')).file|default('browbeat-config.yaml')|basename }}" 
-    
-    - name: Copy browbeat-config
-      copy:
-        src: "{{ test.config.file }}"
-        dest: "{{ browbeat_path }}"
-      when: test.config is defined
-    
+
     - name: Run Browbeat
       shell: |
         source {{browbeat_venv}}/bin/activate
-        ./browbeat.py -s {{ browbeat_config_file }} {{ (test|default({})).workloads|default('rally') }}
+        ./browbeat.py all
       args:
         chdir: "{{ browbeat_path }}"
-


### PR DESCRIPTION
Simplifying execution:
1. We can simply run browbeat with 'all' instead of specifying workloads, as it'll dynamically pick the workloads needed during run time based on browbeat-config file. 
2. Instead of specifying which file to copy to pass it as config file, we'll now template the file so that it dynamically gets built based on environment and parameters passed as this would be more helpful in CI environment and in case the user wanted to run outside CI, it would be pretty straightforward to put the file in templates or get on UC and change the config file, but mostly the plugin is suggested for CI automation.

Adding new roles:
1. template-config role will be run through install, and will help in cases like CI
to template the browbeat-config file.
2. stockpile role to setup stockpile for gathering metadata.
